### PR TITLE
Add an endpoint for authentication verification

### DIFF
--- a/src/api/v1/auth/auth.router.ts
+++ b/src/api/v1/auth/auth.router.ts
@@ -8,6 +8,7 @@ import { RequestHandler, Router } from 'express';
 import { AuthResponse } from '../../../types';
 import logger from '../../../lib/logger';
 import passport from '../../../lib/passport';
+import { authValidator } from '../../../middlewares/auth-validator';
 
 export const authRouter = Router();
 
@@ -35,6 +36,10 @@ authRouter.post('/signin', async (req, res, next) => {
       }
     ) as RequestHandler
   )(req, res, next);
+});
+
+authRouter.get('/verify', authValidator, (req, res) => {
+  res.json(true);
 });
 
 export default authRouter;


### PR DESCRIPTION
This pull request adds a `GET /api/v1/auth/verify` endpoint to verify authentication tokens.

The token is extracted from the Authorization HTTP header.

- If the provided JWT is valid, the server responds with a `200 OK` status and `true` in the response body.
- If the token is invalid or missing, it responds with a `401 Unauthorized` status.