### PR TITLE
Add environment-based CORS origin allowlist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@prisma/client": "^6.6.0",
         "bcryptjs": "^3.0.2",
+        "cors": "^2.8.5",
         "express": "^5.1.0",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
@@ -23,6 +24,7 @@
       "devDependencies": {
         "@eslint/js": "^9.24.0",
         "@stylistic/eslint-plugin": "^4.2.0",
+        "@types/cors": "^2.8.17",
         "@types/eslint__js": "^8.42.3",
         "@types/eslint-plugin-security": "^3.0.0",
         "@types/express": "^5.0.1",
@@ -1210,6 +1212,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -2145,6 +2157,19 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3662,6 +3687,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@prisma/client": "^6.6.0",
     "bcryptjs": "^3.0.2",
+    "cors": "^2.8.5",
     "express": "^5.1.0",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
@@ -59,6 +60,7 @@
   "devDependencies": {
     "@eslint/js": "^9.24.0",
     "@stylistic/eslint-plugin": "^4.2.0",
+    "@types/cors": "^2.8.17",
     "@types/eslint__js": "^8.42.3",
     "@types/eslint-plugin-security": "^3.0.0",
     "@types/express": "^5.0.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,9 +1,12 @@
 import requestLogger from './middlewares/request-logger';
 import errorHandler from './middlewares/error-handler';
+import { ALLOWED_ORIGINS } from './lib/config';
 import AppError from './lib/app-error';
 import apiV1Router from './api/v1';
 import express from 'express';
 import helmet from 'helmet';
+import cors from 'cors';
+import logger from './lib/logger';
 
 const app = express();
 
@@ -12,6 +15,14 @@ app.disable('x-powered-by');
 app.use(helmet());
 app.use(express.json());
 app.use(requestLogger);
+
+logger.info('ALLOWED_ORIGINS: ', ALLOWED_ORIGINS);
+app.use(
+  cors({
+    origin: ALLOWED_ORIGINS,
+    optionsSuccessStatus: 200, // some legacy browsers (IE11, various SmartTVs) choke on 204
+  })
+);
 
 app.use('/api/v1', apiV1Router);
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,12 @@
 if (!process.env.NODE_ENV) console.warn('Miss Env Var: NODE_ENV');
 if (!process.env.SECRET) console.error('Missing Env Var: SECRET');
 if (!process.env.ADMIN_SECRET) console.error('Missing Env Var: ADMIN_SECRET');
+if (!process.env.ALLOWED_ORIGINS)
+  console.log('Missing Env Var: ALLOWED_ORIGINS');
+
+export const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',').map((origin) => origin.trim())
+  : [];
 
 export const SALT = (Number(process.env.SALT) || process.env.SALT) ?? 10;
 export const SECRET = process.env.SECRET ?? 'secret';
@@ -9,4 +15,12 @@ export const TOKEN_EXP_PERIOD = process.env.TOKEN_EXP_PERIOD ?? '3d';
 export const NODE_ENV = process.env.NODE_ENV;
 export const CI = Boolean(process.env.CI);
 
-export default { SALT, SECRET, ADMIN_SECRET, TOKEN_EXP_PERIOD, NODE_ENV, CI };
+export default {
+  TOKEN_EXP_PERIOD,
+  ALLOWED_ORIGINS,
+  ADMIN_SECRET,
+  NODE_ENV,
+  SECRET,
+  SALT,
+  CI,
+};


### PR DESCRIPTION
## Summary

This PR adds a flexible and secure CORS configuration using the `cors` NPM package and environment variables.

- Accepts a comma-separated list of allowed origins from the `ALLOWED_ORIGINS` environment variable.
- Falls back to an empty array `[]` if no value is provided.
- Uses a static array for the `origin` key (no callback needed).

## Motivation

Different environments (local development, staging, production) require different sets of allowed origins for API access. This approach allows for managing CORS origins cleanly without hardcoding them.

## Changes

- Added CORS setup in `app.js` using the `cors` middleware.
- Parsed origins from `process.env.ALLOWED_ORIGINS`.
- Added a fallback to an empty array `[]`.
- Logged the allowlist for easier debugging.

## Example

**.env**
```env
ALLOWED_ORIGINS=http://localhost:3000,https://myfrontend.com
```
**Parsed and used as:**
```
['http://localhost:3000', 'https://myfrontend.com']
```

## Testing

- Verified API accepts requests from the local frontend during development.
- Manually tested CORS rejection from disallowed origins.
- Confirmed fallback works if ALLOWED_ORIGINS is not set.