### PR TITLE
Add generic route access control, apply it to users route, and update `README.md`

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -7,3 +7,5 @@ ADMIN_SECRET=admin_secret
 SECRET=secret
 
 TOKEN_EXP_PERIOD=3d
+
+ALLOWED_ORIGINS=*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,90 @@
 # Generic Express Service
 
-A generic Express.js back-end service that supports multiple front-end projects. Includes RESTful API endpoints, authentication/authorization logic, and maybe some scheduled background jobs for database maintenance.
+A generic Express.js back-end service designed to support multiple front-end apps that I am managing to build in parallel with this app. It includes RESTful API endpoints and user authentication and utilizes PostgreSQL for data persistence.
+
+## Features
+
+- RESTful API with various endpoints serving different purposes
+- User management and authentication endpoints
+- Local PostgreSQL integration via Docker Compose
+- TypeScript support with `tsx` for development
+- Environment-based configuration
+- Tested using Vitest and Supertest
+- Ready for integration with front-end applications
+
+## Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) (tested on v22 but v20 should be fine too)
+- [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/)
+
+## Installation
+
+1. **Clone the repository:**
+
+   ```bash
+   git clone https://github.com/hussein-m-kandil/generic-express-service.git
+   cd generic-express-service
+   ```
+
+2. **Install dependencies:**
+
+   ```bash
+   npm install
+   ```
+
+3. **Set up the environment variables:**
+
+   ```bash
+   cp .env.test .env
+   # Then edit `.env` to fit your local setup
+   ```
+
+4. **Start the PostgreSQL service:**
+
+   ```bash
+   npm run pg:up
+   ```
+
+5. **Push the Prisma schema to the database:**
+
+   ```bash
+   npx prisma db push
+   ```
+
+6. **Start the development server:**
+
+   ```bash
+   npm run dev
+   ```
+
+   The API will be available at `http://localhost:8080`.
+
+## Running all tests
+
+```bash
+npm run test -- --run
+```
+
+## Deployment
+
+Every _push_ or _pull request (PR)_ on main branch, the app will be deployed to production automatically _if it passes all tests and checks performed by [a GitHub action for deployment preparation](./.github/workflows/deployment-prep.yml)_.
+
+## Notes
+
+- This service is intended to support multiple front-end projects that I build.
+- CORS is configured to allow only specific front-end origins under my control.
+- JWT-based authentication is implemented and required by some endpoint.
+- The `Bearer` schema is included in the authentication response, so _send your token as it is_ via an `Authorization` header.
+- All error responses has the proper status code, but not all of them has a body. If an error response has a body it will have _at least_ the following:
+
+  ```json
+  {
+    "error": {
+      "message": "An example error"
+    }
+  }
+  ```
+
+- A validation error response body will have the form of _[ZodError.issues](https://zod.dev/?id=error-handling)._

--- a/requests.rest
+++ b/requests.rest
@@ -1,9 +1,48 @@
+# Admin token
 GET http://127.0.0.1:8080/api/v1/users
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjkzZWE2NjE5LTIyMWEtNDkwYi1iYjcwLWZmZWM0NWQ5MjAyNSIsInVzZXJuYW1lIjoiYWRtaW4iLCJmdWxsbmFtZSI6IkFkbWluIiwiaWF0IjoxNzQ2NDQ2MDA5LCJleHAiOjE3NDY3MDUyMDl9.kIMRW1ctklvIDJf8p_TEMAODHcn3D8HBC6lAkAFDVMs
 
 ###
-GET http://127.0.0.1:8080/api/v1/users/7d517973-7b72-4306-8118-c54021db0585
+
+# Normal user token
+GET http://127.0.0.1:8080/api/v1/users
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjZjNjU1ZDIwLWUyN2QtNDJiMS1hOTNkLWEyYTQxNTA4NzZiZiIsInVzZXJuYW1lIjoibm93aGVyZV9tYW4iLCJmdWxsbmFtZSI6Ik5vd2hlcmUtTWFuIiwiaWF0IjoxNzQ2NDUyMzQ5LCJleHAiOjE3NDY3MTE1NDl9.0lGUkEygKSB5z7RBbKGrP8kY_YeUaoYNISGB9QLWcbc
 
 ###
+
+# Admin token
+GET http://127.0.0.1:8080/api/v1/users/6c655d20-e27d-42b1-a93d-a2a4150876bf
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjkzZWE2NjE5LTIyMWEtNDkwYi1iYjcwLWZmZWM0NWQ5MjAyNSIsInVzZXJuYW1lIjoiYWRtaW4iLCJmdWxsbmFtZSI6IkFkbWluIiwiaWF0IjoxNzQ2NDQ2MDA5LCJleHAiOjE3NDY3MDUyMDl9.kIMRW1ctklvIDJf8p_TEMAODHcn3D8HBC6lAkAFDVMs
+
+###
+
+# Another normal user token
+GET http://127.0.0.1:8080/api/v1/users/93ea6619-221a-490b-bb70-ffec45d92025
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjZjNjU1ZDIwLWUyN2QtNDJiMS1hOTNkLWEyYTQxNTA4NzZiZiIsInVzZXJuYW1lIjoibm93aGVyZV9tYW4iLCJmdWxsbmFtZSI6Ik5vd2hlcmUtTWFuIiwiaWF0IjoxNzQ2NDUyMzQ5LCJleHAiOjE3NDY3MTE1NDl9.0lGUkEygKSB5z7RBbKGrP8kY_YeUaoYNISGB9QLWcbc
+
+###
+
+# Same user token
+GET http://127.0.0.1:8080/api/v1/users/6c655d20-e27d-42b1-a93d-a2a4150876bf
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjZjNjU1ZDIwLWUyN2QtNDJiMS1hOTNkLWEyYTQxNTA4NzZiZiIsInVzZXJuYW1lIjoibm93aGVyZV9tYW4iLCJmdWxsbmFtZSI6Ik5vd2hlcmUtTWFuIiwiaWF0IjoxNzQ2NDUyMzQ5LCJleHAiOjE3NDY3MTE1NDl9.0lGUkEygKSB5z7RBbKGrP8kY_YeUaoYNISGB9QLWcbc
+
+###
+
+# Admin
+POST http://127.0.0.1:8080/api/v1/users
+Content-Type: application/json
+
+{
+  "username": "admin",
+  "fullname": "Admin",
+  "password": "Aa@12312",
+  "confirm": "Aa@12312",
+  "secret": "seco_seco"
+}
+
+###
+
+# Normal user
 POST http://127.0.0.1:8080/api/v1/users
 Content-Type: application/json
 
@@ -15,7 +54,10 @@ Content-Type: application/json
 }
 
 ###
-PATCH http://127.0.0.1:8080/api/v1/users/7d517973-7b72-4306-8118-c54021db0585
+
+# Admin token
+PATCH http://127.0.0.1:8080/api/v1/users/6c655d20-e27d-42b1-a93d-a2a4150876bf
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjkzZWE2NjE5LTIyMWEtNDkwYi1iYjcwLWZmZWM0NWQ5MjAyNSIsInVzZXJuYW1lIjoiYWRtaW4iLCJmdWxsbmFtZSI6IkFkbWluIiwiaWF0IjoxNzQ2NDQ2MDA5LCJleHAiOjE3NDY3MDUyMDl9.kIMRW1ctklvIDJf8p_TEMAODHcn3D8HBC6lAkAFDVMs
 Content-Type: application/json
 
 {
@@ -23,7 +65,10 @@ Content-Type: application/json
 }
 
 ###
-PATCH http://127.0.0.1:8080/api/v1/users/7d517973-7b72-4306-8118-c54021db0585
+
+# Admin token
+PATCH http://127.0.0.1:8080/api/v1/users/6c655d20-e27d-42b1-a93d-a2a4150876bf
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjkzZWE2NjE5LTIyMWEtNDkwYi1iYjcwLWZmZWM0NWQ5MjAyNSIsInVzZXJuYW1lIjoiYWRtaW4iLCJmdWxsbmFtZSI6IkFkbWluIiwiaWF0IjoxNzQ2NDQ2MDA5LCJleHAiOjE3NDY3MDUyMDl9.kIMRW1ctklvIDJf8p_TEMAODHcn3D8HBC6lAkAFDVMs
 Content-Type: application/json
 
 {
@@ -32,13 +77,75 @@ Content-Type: application/json
 }
 
 ###
+
+# Same user token
+PATCH http://127.0.0.1:8080/api/v1/users/6c655d20-e27d-42b1-a93d-a2a4150876bf
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjZjNjU1ZDIwLWUyN2QtNDJiMS1hOTNkLWEyYTQxNTA4NzZiZiIsInVzZXJuYW1lIjoibm93aGVyZV9tYW4iLCJmdWxsbmFtZSI6Ik5vd2hlcmUtTWFuIiwiaWF0IjoxNzQ2NDUyMzQ5LCJleHAiOjE3NDY3MTE1NDl9.0lGUkEygKSB5z7RBbKGrP8kY_YeUaoYNISGB9QLWcbc
+Content-Type: application/json
+
+{
+  "username": "somewhere_man"
+}
+
+###
+
+# Same user token
+PATCH http://127.0.0.1:8080/api/v1/users/6c655d20-e27d-42b1-a93d-a2a4150876bf
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjZjNjU1ZDIwLWUyN2QtNDJiMS1hOTNkLWEyYTQxNTA4NzZiZiIsInVzZXJuYW1lIjoibm93aGVyZV9tYW4iLCJmdWxsbmFtZSI6Ik5vd2hlcmUtTWFuIiwiaWF0IjoxNzQ2NDUyMzQ5LCJleHAiOjE3NDY3MTE1NDl9.0lGUkEygKSB5z7RBbKGrP8kY_YeUaoYNISGB9QLWcbc
+Content-Type: application/json
+
+{
+  "password": "Sm@12312",
+  "confirm": "Sm@12312"
+}
+
+###
+
+# Another user token
+PATCH http://127.0.0.1:8080/api/v1/users/93ea6619-221a-490b-bb70-ffec45d92025
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjZjNjU1ZDIwLWUyN2QtNDJiMS1hOTNkLWEyYTQxNTA4NzZiZiIsInVzZXJuYW1lIjoibm93aGVyZV9tYW4iLCJmdWxsbmFtZSI6Ik5vd2hlcmUtTWFuIiwiaWF0IjoxNzQ2NDUyMzQ5LCJleHAiOjE3NDY3MTE1NDl9.0lGUkEygKSB5z7RBbKGrP8kY_YeUaoYNISGB9QLWcbc
+Content-Type: application/json
+
+{
+  "username": "somewhere_man"
+}
+
+###
+
+# Another user token
+PATCH http://127.0.0.1:8080/api/v1/users/93ea6619-221a-490b-bb70-ffec45d92025
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjZjNjU1ZDIwLWUyN2QtNDJiMS1hOTNkLWEyYTQxNTA4NzZiZiIsInVzZXJuYW1lIjoibm93aGVyZV9tYW4iLCJmdWxsbmFtZSI6Ik5vd2hlcmUtTWFuIiwiaWF0IjoxNzQ2NDUyMzQ5LCJleHAiOjE3NDY3MTE1NDl9.0lGUkEygKSB5z7RBbKGrP8kY_YeUaoYNISGB9QLWcbc
+Content-Type: application/json
+
+{
+  "password": "Sm@12312",
+  "confirm": "Sm@12312"
+}
+
+### 
+
+# Admin token
+DELETE http://127.0.0.1:8080/api/v1/users/7d517973-7b72-4306-8118-c54021db0585
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjkzZWE2NjE5LTIyMWEtNDkwYi1iYjcwLWZmZWM0NWQ5MjAyNSIsInVzZXJuYW1lIjoiYWRtaW4iLCJmdWxsbmFtZSI6IkFkbWluIiwiaWF0IjoxNzQ2NDQ2MDA5LCJleHAiOjE3NDY3MDUyMDl9.kIMRW1ctklvIDJf8p_TEMAODHcn3D8HBC6lAkAFDVMs
+
+### 
+
+# Same user token
+DELETE http://127.0.0.1:8080/api/v1/users/6c655d20-e27d-42b1-a93d-a2a4150876bf
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjZjNjU1ZDIwLWUyN2QtNDJiMS1hOTNkLWEyYTQxNTA4NzZiZiIsInVzZXJuYW1lIjoibm93aGVyZV9tYW4iLCJmdWxsbmFtZSI6Ik5vd2hlcmUtTWFuIiwiaWF0IjoxNzQ2NDUyMzQ5LCJleHAiOjE3NDY3MTE1NDl9.0lGUkEygKSB5z7RBbKGrP8kY_YeUaoYNISGB9QLWcbc
+
+### 
+
+# Another user token
+DELETE http://127.0.0.1:8080/api/v1/users/93ea6619-221a-490b-bb70-ffec45d92025
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjZjNjU1ZDIwLWUyN2QtNDJiMS1hOTNkLWEyYTQxNTA4NzZiZiIsInVzZXJuYW1lIjoibm93aGVyZV9tYW4iLCJmdWxsbmFtZSI6Ik5vd2hlcmUtTWFuIiwiaWF0IjoxNzQ2NDUyMzQ5LCJleHAiOjE3NDY3MTE1NDl9.0lGUkEygKSB5z7RBbKGrP8kY_YeUaoYNISGB9QLWcbc
+
+###
+
 POST http://127.0.0.1:8080/api/v1/auth/signin
 Content-Type: application/json
 
 {
-  "username": "somewhere_man",
-  "password": "Sm@12312"
+  "username": "nowhere_man",
+  "password": "Nm@12312"
 }
-
-### 
-DELETE http://127.0.0.1:8080/api/v1/users/7d517973-7b72-4306-8118-c54021db0585

--- a/src/api/v1/auth/auth.router.ts
+++ b/src/api/v1/auth/auth.router.ts
@@ -8,7 +8,7 @@ import { RequestHandler, Router } from 'express';
 import { AuthResponse } from '../../../types';
 import logger from '../../../lib/logger';
 import passport from '../../../lib/passport';
-import { authValidator } from '../../../middlewares/auth-validator';
+import { authValidator } from '../../../middlewares/validators';
 
 export const authRouter = Router();
 

--- a/src/middlewares/validators.ts
+++ b/src/middlewares/validators.ts
@@ -1,8 +1,55 @@
+import { Request, Response, NextFunction } from 'express';
 import { RequestHandler } from 'express';
+import { AppJwtPayload } from '../types';
 import passport from '../lib/passport';
+import db from '../lib/db';
+
+const isAdmin = async (id: string): Promise<boolean> => {
+  const dbUser = await db.user.findUnique({ where: { id } });
+  return Boolean(dbUser?.isAdmin);
+};
+
+export const createOwnerValidator = (
+  getOwnerId: (req: Request, res: Response) => unknown
+): RequestHandler => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const reqUser = req.user as AppJwtPayload | undefined;
+    const owner = reqUser?.id === (await getOwnerId(req, res));
+    if (owner) next();
+    else res.status(401).end();
+  };
+};
+
+export const createAdminOrOwnerValidator = (
+  getOwnerId: (req: Request, res: Response) => unknown
+): RequestHandler => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const reqUser = req.user as AppJwtPayload | undefined;
+    const admin = reqUser && (await isAdmin(reqUser.id));
+    const owner = reqUser?.id === (await getOwnerId(req, res));
+    if (admin || owner) next();
+    else res.status(401).end();
+  };
+};
+
+export const adminValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const reqUser = req.user as AppJwtPayload | undefined;
+  const admin = reqUser && (await isAdmin(reqUser.id));
+  if (admin) next();
+  else res.status(401).end();
+};
 
 export const authValidator = passport.authenticate('jwt', {
   session: false,
 }) as RequestHandler;
 
-export default { authValidator };
+export default {
+  authValidator,
+  adminValidator,
+  createOwnerValidator,
+  createAdminOrOwnerValidator,
+};

--- a/src/middlewares/validators.ts
+++ b/src/middlewares/validators.ts
@@ -4,3 +4,5 @@ import passport from '../lib/passport';
 export const authValidator = passport.authenticate('jwt', {
   session: false,
 }) as RequestHandler;
+
+export default { authValidator };

--- a/src/tests/api/v1/users.int.test.ts
+++ b/src/tests/api/v1/users.int.test.ts
@@ -24,7 +24,8 @@ import db from '../../../lib/db';
 import bcrypt from 'bcryptjs';
 
 describe('Users endpoint', () => {
-  const BASE_URL = '/api/v1/users';
+  const BASE_URL = '/api/v1';
+  const USERS_ENDPOINT = `${BASE_URL}/users`;
 
   const userData: NewDefaultUser = {
     fullname: 'Clark Kent/Kal-El',
@@ -34,72 +35,41 @@ describe('Users endpoint', () => {
 
   const newUserData: NewUserInput = { ...userData, confirm: userData.password };
 
+  const adminData = {
+    username: 'admin',
+    fullname: 'Administrator',
+    password: 'Aa@12312',
+    isAdmin: true,
+  };
+
   const api = request(app);
 
   const deleteAllUsers = async () => {
     await db.user.deleteMany();
   };
 
+  const createUser = async (data: NewDefaultUser) => {
+    const password = bcrypt.hashSync(data.password, SALT);
+    return await db.user.create({ data: { ...data, password } });
+  };
+
+  const signin = async (username: string, password: string) => {
+    const signinRes = await api
+      .post(`${BASE_URL}/auth/signin`)
+      .send({ username, password });
+    return signinRes.body as AuthResponse;
+  };
+
+  const createAndSigninAdmin = async () => {
+    await createUser(adminData);
+    return await signin(adminData.username, adminData.password);
+  };
+
   beforeEach(deleteAllUsers);
 
   afterAll(deleteAllUsers);
 
-  describe(`GET ${BASE_URL}`, () => {
-    it('should return an empty list', async () => {
-      const res = await api.get(BASE_URL);
-      expect(res.type).toMatch(/json/);
-      expect(res.statusCode).toBe(200);
-      expect(res.body).toEqual(expect.arrayContaining([]));
-      expect(res.body).toHaveLength(0);
-    });
-
-    it('should return the correct user list', async () => {
-      const dbUser = await db.user.create({ data: userData });
-      const res = await api.get(BASE_URL);
-      const users = res.body as User[];
-      expect(res.type).toMatch(/json/);
-      expect(res.statusCode).toBe(200);
-      expect(res.body).toHaveLength(1);
-      expect(users[0].username).toBe(userData.username);
-      expect(users[0].fullname).toBe(userData.fullname);
-      await db.user.delete({ where: { id: dbUser.id } });
-    });
-  });
-
-  describe(`GET ${BASE_URL}/:id`, () => {
-    it('should respond with 400 if given an invalid id', async () => {
-      const res = await api.get(`${BASE_URL}/foo`);
-      const resBody = res.body as AppErrorResponse;
-      expect(res.type).toMatch(/json/);
-      expect(res.statusCode).toBe(400);
-      expect(resBody.error.message).toMatch(/id/i);
-      expect(resBody.error.message).toMatch(/invalid/i);
-    });
-
-    it('should respond with 404 if user does not exit', async () => {
-      const { id } = await db.user.create({ data: userData });
-      await db.user.delete({ where: { id } });
-      const res = await api.get(`${BASE_URL}/${id}`);
-      const resBody = res.body as AppErrorResponse;
-      expect(res.type).toMatch(/json/);
-      expect(res.statusCode).toBe(404);
-      expect(resBody.error.message).toMatch(/not found/i);
-    });
-
-    it('should respond with the found user', async () => {
-      const dbUser = await db.user.create({ data: userData });
-      const res = await api.get(`${BASE_URL}/${dbUser.id}`);
-      const resUser = res.body as User;
-      expect(res.type).toMatch(/json/);
-      expect(res.statusCode).toBe(200);
-      expect(resUser.id).toBe(dbUser.id);
-      expect(resUser.username).toBe(dbUser.username);
-      expect(resUser.password).toBeUndefined();
-      expect(resUser.isAdmin).toBeUndefined();
-    });
-  });
-
-  describe(`POST ${BASE_URL}`, () => {
+  describe(`POST ${USERS_ENDPOINT}`, () => {
     const assertResponseWithValidationError = async (
       res: Response,
       issueField: string
@@ -116,7 +86,7 @@ describe('Users endpoint', () => {
     for (const field of Object.keys(newUserData)) {
       it(`should not create a user without ${field}`, async () => {
         const res = await api
-          .post(BASE_URL)
+          .post(USERS_ENDPOINT)
           .send({ ...newUserData, [field]: undefined });
         await assertResponseWithValidationError(res, field);
       });
@@ -124,14 +94,14 @@ describe('Users endpoint', () => {
 
     it(`should not create a user with wrong password confirmation`, async () => {
       const res = await api
-        .post(BASE_URL)
+        .post(USERS_ENDPOINT)
         .send({ ...userData, confirm: 'blah' });
       await assertResponseWithValidationError(res, 'confirm');
     });
 
     it('should not create a user if the username is already exist', async () => {
-      const { id } = await db.user.create({ data: userData });
-      const res = await api.post(BASE_URL).send(newUserData);
+      const { id } = await createUser(userData);
+      const res = await api.post(USERS_ENDPOINT).send(newUserData);
       const resBody = res.body as AppErrorResponse;
       expect(res.type).toMatch(/json/);
       expect(res.statusCode).toBe(400);
@@ -141,14 +111,14 @@ describe('Users endpoint', () => {
 
     it('should not create an admin user', async () => {
       const res = await api
-        .post(BASE_URL)
+        .post(USERS_ENDPOINT)
         .send({ ...newUserData, secret: 'not_admin' });
       await assertResponseWithValidationError(res, 'secret');
     });
 
     const createPostNewUserTest = (isAdmin: boolean): TestFunction => {
       return async () => {
-        const res = await api.post(BASE_URL).send(
+        const res = await api.post(USERS_ENDPOINT).send(
           isAdmin
             ? {
                 ...newUserData,
@@ -185,27 +155,166 @@ describe('Users endpoint', () => {
     it('should create an admin user', createPostNewUserTest(true));
   });
 
-  describe(`PATCH ${BASE_URL}/:id`, () => {
+  describe(`GET ${USERS_ENDPOINT}`, () => {
+    it('should respond with 401 on request without JWT', async () => {
+      const res = await api.get(USERS_ENDPOINT);
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toStrictEqual({});
+    });
+
+    it('should respond with 401 on request with non-admin JWT', async () => {
+      await createUser(userData);
+      const { token } = await signin(userData.username, userData.password);
+      const res = await api.get(USERS_ENDPOINT).set('Authorization', token);
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toStrictEqual({});
+    });
+
+    it('should respond with users list, on request with admin JWT', async () => {
+      const { token } = await createAndSigninAdmin();
+      const dbUser = await createUser(userData);
+      const res = await api.get(USERS_ENDPOINT).set('Authorization', token);
+      const users = res.body as User[];
+      expect(res.statusCode).toBe(200);
+      expect(res.type).toMatch(/json/);
+      expect(res.body).toHaveLength(2);
+      expect(users[1].username).toBe(userData.username);
+      expect(users[1].fullname).toBe(userData.fullname);
+      await db.user.delete({ where: { id: dbUser.id } });
+    });
+  });
+
+  describe(`GET ${USERS_ENDPOINT}/:id`, () => {
+    it('should respond with 401 on request without JWT', async () => {
+      const dbUser = await createUser(userData);
+      const res = await api.get(`${USERS_ENDPOINT}/${dbUser.id}`);
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toStrictEqual({});
+    });
+
+    it('should respond with 401 on request with non-admin/owner JWT', async () => {
+      const anotherUserData = {
+        username: 'another_user',
+        fullname: 'Another user',
+        password: 'Aa@12312',
+      };
+      await createUser(anotherUserData);
+      const { token } = await signin(
+        anotherUserData.username,
+        anotherUserData.password
+      );
+      const dbUser = await createUser(userData);
+      const res = await api
+        .get(`${USERS_ENDPOINT}/${dbUser.id}`)
+        .set('Authorization', token);
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toStrictEqual({});
+    });
+
+    it('should respond with 401, on request with owner JWT', async () => {
+      await createUser(userData);
+      const { token } = await signin(userData.username, userData.password);
+      const res = await api
+        .get(`${USERS_ENDPOINT}/foo`)
+        .set('Authorization', token);
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toStrictEqual({});
+    });
+
+    it('should respond with 400 if given an invalid id, on request with admin JWT', async () => {
+      const { token } = await createAndSigninAdmin();
+      const res = await api
+        .get(`${USERS_ENDPOINT}/foo`)
+        .set('Authorization', token);
+      const resBody = res.body as AppErrorResponse;
+      expect(res.type).toMatch(/json/);
+      expect(res.statusCode).toBe(400);
+      expect(resBody.error.message).toMatch(/id/i);
+      expect(resBody.error.message).toMatch(/invalid/i);
+    });
+
+    it('should respond with 404 if user does not exit, on request with owner JWT', async () => {
+      const dbUser = await createUser(userData);
+      const { token } = await signin(userData.username, userData.password);
+      await db.user.delete({ where: { id: dbUser.id } });
+      const res = await api
+        .get(`${USERS_ENDPOINT}/${dbUser.id}`)
+        .set('Authorization', token);
+      const resBody = res.body as AppErrorResponse;
+      expect(res.type).toMatch(/json/);
+      expect(res.statusCode).toBe(404);
+      expect(resBody.error.message).toMatch(/not found/i);
+    });
+
+    it('should respond with 404 if user does not exit, on request with admin JWT', async () => {
+      const dbUser = await createUser(userData);
+      const { token } = await createAndSigninAdmin();
+      await db.user.delete({ where: { id: dbUser.id } });
+      const res = await api
+        .get(`${USERS_ENDPOINT}/${dbUser.id}`)
+        .set('Authorization', token);
+      const resBody = res.body as AppErrorResponse;
+      expect(res.type).toMatch(/json/);
+      expect(res.statusCode).toBe(404);
+      expect(resBody.error.message).toMatch(/not found/i);
+    });
+
+    it('should respond with the found user, on request with owner JWT', async () => {
+      const dbUser = await createUser(userData);
+      const { token } = await signin(userData.username, userData.password);
+      const res = await api
+        .get(`${USERS_ENDPOINT}/${dbUser.id}`)
+        .set('Authorization', token);
+      const resUser = res.body as User;
+      expect(res.type).toMatch(/json/);
+      expect(res.statusCode).toBe(200);
+      expect(resUser.id).toBe(dbUser.id);
+      expect(resUser.username).toBe(dbUser.username);
+      expect(resUser.password).toBeUndefined();
+      expect(resUser.isAdmin).toBeUndefined();
+    });
+
+    it('should respond with the found user, on request with admin JWT', async () => {
+      const { token } = await createAndSigninAdmin();
+      const dbUser = await createUser(userData);
+      const res = await api
+        .get(`${USERS_ENDPOINT}/${dbUser.id}`)
+        .set('Authorization', token);
+      const resUser = res.body as User;
+      expect(res.type).toMatch(/json/);
+      expect(res.statusCode).toBe(200);
+      expect(resUser.id).toBe(dbUser.id);
+      expect(resUser.username).toBe(dbUser.username);
+      expect(resUser.password).toBeUndefined();
+      expect(resUser.isAdmin).toBeUndefined();
+    });
+  });
+
+  describe(`PATCH ${USERS_ENDPOINT}/:id`, () => {
     let longString = '';
     for (let i = 0; i < 1000; i++) longString += 'x';
 
     let dbUser: User;
     beforeEach(async () => {
-      dbUser = await db.user.create({
-        data: {
-          ...userData,
-          password: bcrypt.hashSync(userData.password, SALT),
-        },
-      });
+      await createUser(adminData);
+      dbUser = await createUser(userData);
     });
 
     afterEach(deleteAllUsers);
 
     const createTestForUpdateField = (
-      data: Prisma.UserUpdateInput & { confirm?: string; secret?: string }
+      data: Prisma.UserUpdateInput & { confirm?: string; secret?: string },
+      credentials: { username: string; password: string }
     ) => {
       return async () => {
-        const res = await api.patch(`${BASE_URL}/${dbUser.id}`).send(data);
+        const { token } = await signin(
+          credentials.username,
+          credentials.password
+        );
+        const res = await api
+          .patch(`${USERS_ENDPOINT}/${dbUser.id}`)
+          .set('Authorization', token)
+          .send(data);
         const updatedDBUser = await db.user.findUnique({
           where: { id: dbUser.id },
         });
@@ -244,10 +353,18 @@ describe('Users endpoint', () => {
 
     const createTestForNotUpdateInvalidField = (
       data: Prisma.UserUpdateInput & { confirm?: string; secret?: string },
-      expectedErrMsgRegex: RegExp
+      expectedErrMsgRegex: RegExp,
+      credentials: { username: string; password: string }
     ) => {
       return async () => {
-        const res = await api.patch(`${BASE_URL}/${dbUser.id}`).send(data);
+        const { token } = await signin(
+          credentials.username,
+          credentials.password
+        );
+        const res = await api
+          .patch(`${USERS_ENDPOINT}/${dbUser.id}`)
+          .set('Authorization', token)
+          .send(data);
         const issues = res.body as ZodIssue[];
         expect(res.type).toMatch(/json/);
         expect(res.statusCode).toBe(400);
@@ -255,11 +372,40 @@ describe('Users endpoint', () => {
       };
     };
 
-    it('should not change username if the given is already exists', async () => {
-      const username = 'foobar';
-      await db.user.create({ data: { ...userData, username } });
+    it('should respond with 401, on a request without JWT', async () => {
       const res = await api
-        .patch(`${BASE_URL}/${dbUser.id}`)
+        .patch(`${USERS_ENDPOINT}/${dbUser.id}`)
+        .send({ username: 'foobar' });
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toStrictEqual({});
+    });
+
+    it('should respond with 401, on a request with non-owner/admin JWT', async () => {
+      const otherUserData = {
+        username: 'other_user',
+        fullname: 'Other User',
+        password: 'Oo@12312',
+      };
+      await createUser(otherUserData);
+      const { token } = await signin(
+        otherUserData.username,
+        otherUserData.password
+      );
+      const res = await api
+        .patch(`${USERS_ENDPOINT}/${dbUser.id}`)
+        .set('Authorization', token)
+        .send({ username: 'foobar' });
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toStrictEqual({});
+    });
+
+    it('should not change username if the given is already exists, on request with owner JWT', async () => {
+      const username = 'foobar';
+      await createUser({ ...userData, username });
+      const { token } = await signin(userData.username, userData.password);
+      const res = await api
+        .patch(`${USERS_ENDPOINT}/${dbUser.id}`)
+        .set('Authorization', token)
         .send({ username });
       const resBody = res.body as AppErrorResponse;
       expect(res.type).toMatch(/json/);
@@ -269,96 +415,171 @@ describe('Users endpoint', () => {
     });
 
     it(
-      'should change username',
-      createTestForUpdateField({ username: 'new_username' })
+      'should change username, on request with owner/admin JWT',
+      createTestForUpdateField({ username: 'new_username' }, userData)
     );
 
     it(
-      'should not change username if the given is too short',
-      createTestForNotUpdateInvalidField({ username: 'x' }, /username/i)
+      'should not change username if the given is too short, on request with owner/admin JWT',
+      createTestForNotUpdateInvalidField(
+        { username: 'x' },
+        /username/i,
+        userData
+      )
     );
 
     it(
-      'should not change username if the given is too long',
-      createTestForNotUpdateInvalidField({ username: longString }, /username/i)
+      'should not change username if the given is too long, on request with owner/admin JWT',
+      createTestForNotUpdateInvalidField(
+        { username: longString },
+        /username/i,
+        adminData
+      )
     );
 
     it(
-      'should change fullname',
-      createTestForUpdateField({ fullname: 'new_fullname' })
+      'should change fullname, on request with owner/admin JWT',
+      createTestForUpdateField({ fullname: 'new_fullname' }, adminData)
     );
 
     it(
-      'should not change fullname if the given is too short',
-      createTestForNotUpdateInvalidField({ fullname: 'x' }, /fullname/i)
+      'should not change fullname if the given is too short, on request with owner/admin JWT',
+      createTestForNotUpdateInvalidField(
+        { fullname: 'x' },
+        /fullname/i,
+        userData
+      )
     );
 
     it(
-      'should not change fullname if the given is too long',
-      createTestForNotUpdateInvalidField({ fullname: longString }, /fullname/i)
+      'should not change fullname if the given is too long, on request with owner/admin JWT',
+      createTestForNotUpdateInvalidField(
+        { fullname: longString },
+        /fullname/i,
+        adminData
+      )
     );
 
     it(
-      'should change password',
-      createTestForUpdateField({ password: 'aB@32121', confirm: 'aB@32121' })
+      'should change password, on request with owner/admin JWT',
+      createTestForUpdateField(
+        { password: 'aB@32121', confirm: 'aB@32121' },
+        userData
+      )
     );
 
     it(
-      'should not change password if given a malformed one',
+      'should not change password if given a malformed one, on request with owner/admin JWT',
       createTestForNotUpdateInvalidField(
         { password: '12345678', confirm: '12345678' },
-        /password/i
+        /password/i,
+        userData
       )
     );
 
     it(
-      'should not change password if not given a the confirmation',
+      'should not change password if not given a the confirmation, on request with owner/admin JWT',
       createTestForNotUpdateInvalidField(
         { password: 'aB@32121' },
-        /password confirmation/i
+        /password confirmation/i,
+        adminData
       )
     );
 
     it(
-      'should not change password if given not matched confirmation',
+      'should not change password if given not matched confirmation, on request with owner/admin JWT',
       createTestForNotUpdateInvalidField(
         { password: 'aB@32121', confirm: '12345678' },
-        /passwords does not match/i
+        /passwords does not match/i,
+        userData
       )
     );
 
     it(
-      'should change admin state',
-      createTestForUpdateField({ secret: ADMIN_SECRET })
+      'should change admin state, on request with owner/admin JWT',
+      createTestForUpdateField({ secret: ADMIN_SECRET }, adminData)
     );
 
     it(
-      'should not change admin state if given a wrong secret',
-      createTestForNotUpdateInvalidField({ secret: 'not_admin' }, /secret/i)
+      'should not change admin state if given a wrong secret, on request with owner/admin JWT',
+      createTestForNotUpdateInvalidField(
+        { secret: 'not_admin' },
+        /secret/i,
+        adminData
+      )
     );
   });
 
-  describe(`DELETE ${BASE_URL}/:id`, () => {
-    it('should respond with 204 if found a user and deleted it', async () => {
-      const dbUser = await db.user.create({ data: userData });
-      const res = await api.delete(`${BASE_URL}/${dbUser.id}`);
+  describe(`DELETE ${USERS_ENDPOINT}/:id`, () => {
+    it('should respond with 401 on request without JWT', async () => {
+      const dbUser = await createUser(userData);
+      const res = await api.delete(`${USERS_ENDPOINT}/${dbUser.id}`);
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toStrictEqual({});
+    });
+
+    it('should respond with 401 on request with non-owner/admin JWT', async () => {
+      await createUser(userData);
+      const { token } = await signin(userData.username, userData.password);
+      const userDataToDel = {
+        username: 'to_delete',
+        fullname: 'To Delete',
+        password: 'Dd@12312',
+      };
+      const dbUser = await createUser(userDataToDel);
+      const res = await api
+        .delete(`${USERS_ENDPOINT}/${dbUser.id}`)
+        .set('Authorization', token);
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toStrictEqual({});
+    });
+
+    it('should respond with 204 if found a user and deleted it, on request with owner JWT', async () => {
+      const dbUser = await createUser(userData);
+      const { token } = await signin(userData.username, userData.password);
+      const res = await api
+        .delete(`${USERS_ENDPOINT}/${dbUser.id}`)
+        .set('Authorization', token);
       expect(res.statusCode).toBe(204);
     });
 
-    it('should respond with 204 if not found a user', async () => {
-      const { id } = await db.user.create({ data: userData });
-      await db.user.delete({ where: { id } });
-      const res = await api.delete(`${BASE_URL}/${id}`);
+    it('should respond with 204 if found a user and deleted it, on request with admin JWT', async () => {
+      const dbUser = await createUser(userData);
+      const { token } = await createAndSigninAdmin();
+      const res = await api
+        .delete(`${USERS_ENDPOINT}/${dbUser.id}`)
+        .set('Authorization', token);
       expect(res.statusCode).toBe(204);
     });
 
-    it('should respond with 400 if the id is invalid', async () => {
-      const res = await api.delete(`${BASE_URL}/foo`);
-      const resBody = res.body as AppErrorResponse;
-      expect(res.type).toMatch(/json/);
-      expect(res.statusCode).toBe(400);
-      expect(resBody.error.message).toMatch(/id/i);
-      expect(resBody.error.message).toMatch(/invalid/i);
+    it('should respond with 204 if not found a user, on request with owner JWT', async () => {
+      const dbUser = await createUser(userData);
+      const { token } = await signin(userData.username, userData.password);
+      await db.user.delete({ where: { id: dbUser.id } });
+      const res = await api
+        .delete(`${USERS_ENDPOINT}/${dbUser.id}`)
+        .set('Authorization', token);
+      expect(res.statusCode).toBe(204);
+    });
+
+    it('should respond with 204 if not found a user, on request with admin JWT', async () => {
+      const dbUser = await createUser(userData);
+      await db.user.delete({ where: { id: dbUser.id } });
+      const { token } = await createAndSigninAdmin();
+      const res = await api
+        .delete(`${USERS_ENDPOINT}/${dbUser.id}`)
+        .set('Authorization', token);
+      expect(res.statusCode).toBe(204);
+    });
+
+    it('should respond with 401 if the id is invalid', async () => {
+      await createUser(userData);
+      const { token } = await signin(userData.username, userData.password);
+      const res = await api
+        .delete(`${USERS_ENDPOINT}/foo`)
+        .set('Authorization', token);
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toStrictEqual({});
     });
   });
 });


### PR DESCRIPTION
This pull request introduces a generic route protection mechanism, currently applied to the `/users` route, and designed to support other routes in the future. It also includes project details added to the `README.md`.

### What’s New

- 🔐 Restricted access to user data—only the user themself or an admin can modify user data.
- 🧼 Refactored `authValidator` middleware into a reusable module of middleware/middleware-creators for improved maintainability.
- 🌐 Allowed all origins in the `.env.test` file to better support testing workflows.
- 📝 Updated `README.md` with basic project information.
