### PR TITLE
Add an endpoint for signed-in user data and minimize the JWT payload

### DIFF
--- a/requests/users.rest
+++ b/requests/users.rest
@@ -152,6 +152,11 @@ Content-Type: application/json
 
 ###
 
+GET http://127.0.0.1:8080/api/v1/auth/me
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjQyMDZmYTEwLWM2NTQtNDRlNi04ZjRhLTU4MWI2NmI0NzE2ZiIsImlzQWRtaW4iOmZhbHNlLCJpYXQiOjE3NDc3NjA3NTgsImV4cCI6MTc0ODAxOTk1OH0.DF7lFdLIqy4MrkvkAWYjn6uOQq8dCcCS5-DibV-aBPA
+
+###
+
 GET http://127.0.0.1:8080/api/v1/users/3f457861-0abb-40a9-9603-dcaad46f224c/posts
 
 ###

--- a/src/api/v1/auth/auth.router.ts
+++ b/src/api/v1/auth/auth.router.ts
@@ -33,6 +33,10 @@ authRouter.post('/signin', async (req, res, next) => {
   )(req, res, next);
 });
 
+authRouter.get('/me', authValidator, (req, res) => {
+  res.json(req.user);
+});
+
 authRouter.get('/verify', authValidator, (req, res) => {
   res.json(true);
 });

--- a/src/api/v1/posts/posts.router.ts
+++ b/src/api/v1/posts/posts.router.ts
@@ -14,7 +14,7 @@ import {
   getVoteFilterOptionsFromReqQuery,
 } from '../../../lib/helpers';
 import { Request, Response, Router } from 'express';
-import { AppJwtPayload } from '../../../types';
+import { PublicUser } from '../../../types';
 import postsService from './posts.service';
 import postSchema, { commentSchema } from './post.schema';
 
@@ -55,7 +55,7 @@ postsRouter.get('/', optionalAuthValidator, async (req, res) => {
 });
 
 postsRouter.get('/count', authValidator, async (req, res) => {
-  const user = req.user as AppJwtPayload;
+  const user = req.user as PublicUser;
   const postsCount = await postsService.countPostsByAuthorId(user.id);
   res.json(postsCount);
 });
@@ -65,14 +65,14 @@ postsRouter.get('/categories', async (req, res) => {
 });
 
 postsRouter.get('/categories/count', authValidator, async (req, res) => {
-  const user = req.user as AppJwtPayload;
+  const user = req.user as PublicUser;
   const categoriesCount =
     await postsService.countPostsCategoriesByPostsAuthorId(user.id);
   res.json(categoriesCount);
 });
 
 postsRouter.get('/comments/count', authValidator, async (req, res) => {
-  const user = req.user as AppJwtPayload;
+  const user = req.user as PublicUser;
   const commentsCount = await postsService.countPostsCommentsByPostsAuthorId(
     user.id
   );
@@ -80,7 +80,7 @@ postsRouter.get('/comments/count', authValidator, async (req, res) => {
 });
 
 postsRouter.get('/votes/count', authValidator, async (req, res) => {
-  const user = req.user as AppJwtPayload;
+  const user = req.user as PublicUser;
   const votesCount = await postsService.countPostsVotesByPostsAuthorId(user.id);
   res.json(votesCount);
 });
@@ -148,20 +148,20 @@ postsRouter.get(
 );
 
 postsRouter.post('/', authValidator, async (req, res) => {
-  const user = req.user as AppJwtPayload;
+  const user = req.user as PublicUser;
   const postData = { ...postSchema.parse(req.body), authorId: user.id };
   const createdPost = await postsService.createPost(postData);
   res.status(201).json(createdPost);
 });
 
 postsRouter.post('/:id/upvote', authValidator, async (req, res) => {
-  const user = req.user as AppJwtPayload;
+  const user = req.user as PublicUser;
   const upvotedPost = await postsService.upvotePost(req.params.id, user.id);
   res.json(upvotedPost);
 });
 
 postsRouter.post('/:id/downvote', authValidator, async (req, res) => {
-  const user = req.user as AppJwtPayload;
+  const user = req.user as PublicUser;
   const downvotedPost = await postsService.downvotePost(req.params.id, user.id);
   res.json(downvotedPost);
 });
@@ -170,7 +170,7 @@ postsRouter.post(
   '/:id/comments',
   authValidator,
   async (req: Request<{ id: string }, unknown, { content: string }>, res) => {
-    const user = req.user as AppJwtPayload;
+    const user = req.user as PublicUser;
     const commentData = commentSchema.parse(req.body);
     const updatedPost = await postsService.findPostByIdAndCreateComment(
       req.params.id,
@@ -197,7 +197,7 @@ postsRouter.put(
   authValidator,
   createOwnerValidator(getCommentAuthorId),
   async (req, res) => {
-    const user = req.user as AppJwtPayload;
+    const user = req.user as PublicUser;
     const commentData = commentSchema.parse(req.body);
     const updatedPost = await postsService.findPostCommentByCompoundIdAndUpdate(
       req.params.pId,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -18,7 +18,8 @@ if (globalForPrisma.prisma) {
   prismaClient = new PrismaClient({
     // Read the URL programmatically to support replacing .env with .env.test in CLI
     datasourceUrl: process.env.DATABASE_URL,
-    omit: { user: { password: true, isAdmin: true } },
+    // Globally omit the password field; need to be sat to false explicitly, to retrieve a user with password
+    omit: { user: { password: true } },
   });
 }
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -19,8 +19,8 @@ import db from './db';
 import ms from 'ms';
 
 export const createJwtForUser = (user: PublicUser): string => {
-  const { id, username, fullname } = user;
-  const payload: AppJwtPayload = { id, username, fullname };
+  const { id, isAdmin } = user;
+  const payload: AppJwtPayload = { id, isAdmin };
   const token = jwt.sign(payload, SECRET, {
     expiresIn: TOKEN_EXP_PERIOD as ms.StringValue,
   });
@@ -88,7 +88,7 @@ export const getVoteTypeFilterFromReqQuery = (req: Request) => {
 export const getSignedInUserIdFromReqQuery = (req: Request) => {
   let userId;
   if (req.user) {
-    userId = (req.user as AppJwtPayload).id;
+    userId = (req.user as PublicUser).id;
   }
   return userId;
 };

--- a/src/lib/passport.ts
+++ b/src/lib/passport.ts
@@ -39,7 +39,16 @@ passport.use(
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       secretOrKey: SECRET,
     },
-    (jwtPayload: AppJwtPayload, done) => done(null, jwtPayload)
+    (jwtPayload: AppJwtPayload, done) => {
+      const { id } = jwtPayload;
+      db.user
+        .findUnique({ where: { id } })
+        .then((user) => {
+          if (user) done(null, user);
+          else done(null, false);
+        })
+        .catch((error: unknown) => done(error, false));
+    }
   )
 );
 

--- a/src/tests/api/v1/auth.int.test.ts
+++ b/src/tests/api/v1/auth.int.test.ts
@@ -1,12 +1,19 @@
 import { AppErrorResponse, AuthResponse } from '../../../types';
 import { it, expect, describe, afterAll, beforeAll, vi } from 'vitest';
 import { User } from '../../../../prisma/generated/client';
-import { SIGNIN_URL, VERIFY_URL } from './utils';
+import { SIGNIN_URL, VERIFY_URL, SIGNED_IN_USER_URL } from './utils';
 import jwt from 'jsonwebtoken';
 import setup from '../setup';
 
 describe('Authentication endpoint', async () => {
-  const { api, userData, createUser, deleteAllUsers } = await setup(SIGNIN_URL);
+  const {
+    api,
+    userData,
+    createUser,
+    deleteAllUsers,
+    prepForAuthorizedTest,
+    assertUnauthorizedErrorRes,
+  } = await setup(SIGNIN_URL);
 
   let dbUser: User;
 
@@ -100,6 +107,36 @@ describe('Authentication endpoint', async () => {
         .get(VERIFY_URL)
         .set('Authorization', signinResBody.token);
       expect(res.statusCode).toBe(401);
+    });
+  });
+
+  describe(`GET ${SIGNED_IN_USER_URL}`, () => {
+    it('should respond with 401 if the user is not found', async () => {
+      const { authorizedApi } = await prepForAuthorizedTest(userData);
+      await deleteAllUsers();
+      const res = await authorizedApi.get(SIGNED_IN_USER_URL);
+      dbUser = await createUser(userData); // All tests expects this user to be exist
+      assertUnauthorizedErrorRes(res);
+    });
+
+    it('should respond with 401 if the JWT is invalid', async () => {
+      const res = await api
+        .get(SIGNED_IN_USER_URL)
+        .set('Authorization', 'blah');
+      assertUnauthorizedErrorRes(res);
+    });
+
+    it('should respond with current signed in user data base on the JWT', async () => {
+      const { authorizedApi } = await prepForAuthorizedTest(userData);
+      const res = await authorizedApi.get(SIGNED_IN_USER_URL);
+      const resBody = res.body as User;
+      expect(res.statusCode).toBe(200);
+      expect(res.type).toMatch(/json/);
+      expect(resBody.password).toBeUndefined();
+      expect(resBody.id).toStrictEqual(dbUser.id);
+      expect(resBody.isAdmin).toStrictEqual(false);
+      expect(resBody.username).toBe(dbUser.username);
+      expect(resBody.fullname).toBe(dbUser.fullname);
     });
   });
 });

--- a/src/tests/api/v1/utils.ts
+++ b/src/tests/api/v1/utils.ts
@@ -9,3 +9,5 @@ export const POSTS_URL = `${BASE_URL}/posts`;
 export const SIGNIN_URL = `${BASE_URL}/auth/signin`;
 
 export const VERIFY_URL = `${BASE_URL}/auth/verify`;
+
+export const SIGNED_IN_USER_URL = `${BASE_URL}/auth/me`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,6 @@ export interface DBKnownErrorsHandlerOptions {
 
 export interface UserSensitiveDataToOmit {
   password: true;
-  isAdmin: true;
 }
 
 export type CustomPrismaClient = PrismaClient<{
@@ -29,7 +28,7 @@ export type NewUserInput = z.input<typeof userSchema>;
 export type NewUserOutput = z.output<typeof userSchema>;
 
 export type JwtUser = Prisma.UserGetPayload<{
-  select: { id: true; username: true; fullname: true };
+  select: { id: true; isAdmin: true };
 }>;
 
 export type AppJwtPayload = JwtPayload & JwtUser;


### PR DESCRIPTION
This pull request introduces a dedicated endpoint to fetch the authenticated user's data. It also updates the authentication logic to reduce the JWT payload to essential fields only, without any personally identifiable information (PII). On verification, the full user data is queried from the database instead of being embedded in the token.

### What’s New

- ➕ Added `GET /api/v1/auth/me` to return the authenticated user's data.
- ⚙️ Reduced the JWT payload to include only the user ID and their role.
- 🗃️ Updated the token verification logic to fetch the full user record from the DB.
